### PR TITLE
Add attribution for boot commands

### DIFF
--- a/bin/macOS-15.arm64.lume.prepare-01.pkr.hcl
+++ b/bin/macOS-15.arm64.lume.prepare-01.pkr.hcl
@@ -62,6 +62,7 @@ source "lume-cli" "lume" {
 
   # headless     = true
 
+  # Modified from https://github.com/cirruslabs/macos-image-templates/blob/5f66cb1ca2f31ddbbdff34be5e3561584cd67d4b/templates/vanilla-sequoia.pkr.hcl
   boot_command = [
     # hello, hola, bonjour, etc.
     "<wait60s><spacebar>",


### PR DESCRIPTION
The boot commands in this file appear to be modified from [this commit][1], which requires attribution to comply with the MIT license terms.

[1]: https://github.com/cirruslabs/macos-image-templates/blob/5f66cb1ca2f31ddbbdff34be5e3561584cd67d4b/templates/vanilla-sequoia.pkr.hcl